### PR TITLE
Remove Azure Functions Core Tools from the container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,9 +24,6 @@
 		"ghcr.io/stuartleeks/dev-container-features/azure-cli-persistence:0": {},
 		"ghcr.io/natescherer/devcontainers-custom-features/powershell-resources:1": {
 			"resources": "Az,Microsoft.Graph,Microsoft.Graph.Beta"
-		},
-		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
-			"version": "latest"
 		}
 	}
 


### PR DESCRIPTION
Feature doesn't work out of the box, so remove it for now.